### PR TITLE
Reload GaugeChart when nedleValue option is changed

### DIFF
--- a/index.vue
+++ b/index.vue
@@ -33,8 +33,15 @@ export default {
                 let element = document.querySelector("#"+this.gaugeId );
                 
                 // Drawing and updating the chart
-                GaugeChart.gaugeChart(element, config.chartWidth, config).updateNeedle(config.needleValue); 
+                this.gauge = GaugeChart.gaugeChart(element, config.chartWidth, config);
+                this.gauge.updateNeedle(config.needleValue); 
             }  
+        },
+        reloadPlugin() {
+            if (this.gauge) {
+                this.gauge.removeGauge();
+            }
+            this.initPlugin(this.options);
         }
     },
     computed: {
@@ -45,5 +52,13 @@ export default {
             return "vue-gauge";
         }
     },
+    watch: {
+        options: function(newOptions, oldOptions) {
+            // Reload gauge on nedleValue change
+            if (newOptions.needleValue != oldOptions.needleValue) {
+                this.reloadPlugin();
+            }
+        }
+    }
 }
 </script>

--- a/index.vue
+++ b/index.vue
@@ -54,9 +54,20 @@ export default {
     },
     watch: {
         options: function(newOptions, oldOptions) {
+            
             // Reload gauge on nedleValue change
             if (newOptions.needleValue != oldOptions.needleValue) {
-                this.reloadPlugin();
+
+                // If you update centralLabel option, you have to reload GaugeChart instance
+                if (newOptions.centralLabel != oldOptions.centralLabel) {
+                    this.reloadPlugin();
+                }
+
+                // Otherwise updateNeedle is called
+                else {
+                    this.gauge.updateNeedle(newOptions.needleValue);
+                }
+                
             }
         }
     }


### PR DESCRIPTION
When needleValue option is changed, the GaugeChart instance is removed and created again with the new value. The GaugeChart.updateNeedle method only updates needle position, but if you need to update needle position with the centralLabel option, the GaugeChart instance has to be removed and created again.